### PR TITLE
Document procedure for major and minor releases

### DIFF
--- a/Procedures/MA-StandardReleases.md
+++ b/Procedures/MA-StandardReleases.md
@@ -5,7 +5,7 @@ In order avoid delays or rejections of a release, it is recommended that MA memb
 Additionally the announcement of the MA vote can be done during the MAP-internal vote to avoid delays.
 
 For MA approval vote, the MAP leader asks MA Backoffice to initiate voting.
-MA Backoffice then announces the voting and organizes electronics voting.
+MA Backoffice then announces the voting and organizes electronic voting.
 
 # Procedure for bugfix / maintenance release of MA standards
 The following procedure is recommended for the bugfix/maintenance releases of MA standards with no new features (typically "third digit" releases following semantic versioning):

--- a/Procedures/MA-StandardReleases.md
+++ b/Procedures/MA-StandardReleases.md
@@ -1,6 +1,6 @@
 # Procedure for major and minor releases of MA standards
 These releases of Modelica Association are first voted on in the MAP. The release is then voted on by the MA members according to the bylaws.
-In order avoid delays or rejections of a releaserelease, it is recommended that MA members are already during the MAP-internal finalization of a version are asked to inspect it and provide feedback.
+In order avoid delays or rejections of a release, it is recommended that MA members are already asked for inspection and feedback, during the MAP-internal finalization of a version.
 
 # Procedure for bugfix / maintenance release of MA standards
 The following procedure is recommended for the bugfix/maintenance releases of MA standards with no new features (typically "third digit" releases following semantic versioning):

--- a/Procedures/MA-StandardReleases.md
+++ b/Procedures/MA-StandardReleases.md
@@ -1,3 +1,7 @@
+# Procedure for major and minor releases of MA standards
+These releases of Modelica Association are first voted on in the MAP. The release is then voted on by the MA members according to the bylaws.
+In order avoid delays or rejections of a releaserelease, it is recommended that MA members are already during the MAP-internal finalization of a version are asked to inspect it and provide feedback.
+
 # Procedure for bugfix / maintenance release of MA standards
 The following procedure is recommended for the bugfix/maintenance releases of MA standards with no new features (typically "third digit" releases following semantic versioning):
 

--- a/Procedures/MA-StandardReleases.md
+++ b/Procedures/MA-StandardReleases.md
@@ -1,6 +1,7 @@
 # Procedure for major and minor releases of MA standards
 These releases of Modelica Association are first voted on in the MAP. The release is then voted on by the MA members according to the bylaws.
 In order avoid delays or rejections of a release, it is recommended that MA members are already asked for inspection and feedback, during the MAP-internal finalization of a version.
+Additionally the announcement of the MA vote can be done during the MAP-internal vote to avoid delays.
 
 # Procedure for bugfix / maintenance release of MA standards
 The following procedure is recommended for the bugfix/maintenance releases of MA standards with no new features (typically "third digit" releases following semantic versioning):

--- a/Procedures/MA-StandardReleases.md
+++ b/Procedures/MA-StandardReleases.md
@@ -1,15 +1,19 @@
 # Procedure for major and minor releases of MA standards
 These releases of Modelica Association are first voted on in the MAP. The release is then voted on by the MA members according to the bylaws.
+
 In order avoid delays or rejections of a release, it is recommended that MA members are already asked for inspection and feedback, during the MAP-internal finalization of a version.
 Additionally the announcement of the MA vote can be done during the MAP-internal vote to avoid delays.
+
+For MA approval vote, the MAP leader asks MA Backoffice to initiate voting.
+MA Backoffice then announces the voting and organizes electronics voting.
 
 # Procedure for bugfix / maintenance release of MA standards
 The following procedure is recommended for the bugfix/maintenance releases of MA standards with no new features (typically "third digit" releases following semantic versioning):
 
-The MAP announces to both the MA board and the backoffice the planned maintenance release and availability of relevant document(s).
+The MAP announces to both the MA Board and the MA Backoffice the planned maintenance release and availability of relevant document(s).
 The backoffice or the MAP announces the inspection period to the MA members (minimum of 4 weeks).
 During this period, anyone can comment and the MAP shall react.
-If there is no agreement between MAP and feedback provider, the MA board must decide if a "normal process" with full MA acceptance vote is necessary. 
+If there is no agreement between MAP and feedback provider, the MA Board must decide if a "normal process" with full MA acceptance vote is necessary. 
 In the last week of the inspection period, only editorial or typographic changes are allowed.
 Otherwise the inspection period restarts.
 If there are no blockers, the MAP may release the maintenance version of the MA standard.


### PR DESCRIPTION
Added a section for major and minor releases of MA standards, including voting procedures and feedback recommendations.